### PR TITLE
ENH: Add a Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM debian:jessie
+
+RUN apt-get update
+RUN apt-get install -y libwebp5 libfontconfig libjpeg62 libssl1.0.0 libicu52 curl
+
+COPY . decktape
+WORKDIR decktape
+RUN curl \
+    -L https://astefanutti.github.io/decktape/downloads/phantomjs-linux-debian8-x86-64 \
+    -o bin/phantomjs
+ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
I used decktape to export a [Jupyter Notebook Slideshow](https://github.com/damianavila/RISE) last night and found the installation a bit challenging.  In particular, getting the forked version of phantomjs up and running was a bit of a challenge because it dynamically links against several librariesa.

The easiest way I ultimately found to run decktape was to build a [docker](https://github.com/docker/docker) image based on debian:jessie that installed all the dependencies and the pre-built phantomjs.  This PR adds the Dockerfile I used to export my slides.

The expected workflow for using this container would be something like the following:
```
<start local process serving slides on http://localhost:8000/Talk.slides.html >
cd <decktape>
docker build -t decktape .
docker run -it decktape  # This drops the user in a bash 
./bin/phantomjs decktape.js automatic http://localhost:8000/Talk.slides.html slides.pdf
```
In another shell, you'd copy the output file out of the container by running:
```docker cp <container-id>:decktape/slides.pdf slides.pdf.```

This process could probably be scripted a bit more to not require as many manual steps, but this seemed like a good first pass at making it easier to get set up with decktape via docker.