### PR TITLE
Add a native exporter for Bespoke.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ DeckTape is a high-quality PDF exporter for HTML5 presentation frameworks. It su
 
 DeckTape is built on top of [PhantomJS](http://phantomjs.org) which relies on [Qt WebKit](https://wiki.qt.io/Qt_WebKit) for laying out and rendering Web pages and provides a headless WebKit scriptable with a JavaScript API.
 
-DeckTape currently supports the [CSSS](http://leaverou.github.io/csss/), [deck.js](http://imakewebthings.com/deck.js/), [DZSlides](http://paulrouget.com/dzslides/), [flowtime.js](http://flowtime-js.marcolago.com), [HTML Slidy](http://www.w3.org/Talks/Tools/), [impress.js](http://impress.github.io/impress.js), [remark.js](http://remarkjs.com), [reveal.js](http://lab.hakim.se/reveal-js) and [Shower](http://shwr.me/) presentation frameworks out-of-the-box. Besides, DeckTape provides a [generic command](#generic) that emulates the end-user interaction and that can be used to convert presentations from virtually any kind of frameworks. That is particularly useful to support HTML presentation frameworks that don't expose any API nor accessible state, like [Bespoke.js](https://github.com/markdalgleish/bespoke.js) for example.
+DeckTape currently supports the [Bespoke.js](https://github.com/markdalgleish/bespoke.js), [CSSS](http://leaverou.github.io/csss/), [deck.js](http://imakewebthings.com/deck.js/), [DZSlides](http://paulrouget.com/dzslides/), [flowtime.js](http://flowtime-js.marcolago.com), [HTML Slidy](http://www.w3.org/Talks/Tools/), [impress.js](http://impress.github.io/impress.js), [remark.js](http://remarkjs.com), [reveal.js](http://lab.hakim.se/reveal-js) and [Shower](http://shwr.me/) presentation frameworks out-of-the-box.
+
+DeckTape also provides a [generic command](#generic) that emulates the end-user interaction and that can be used to convert presentations from virtually any kind of frameworks. This mode is particularly useful to support HTML presentation frameworks that don't expose any API nor accessible state.
 
 DeckTape's plugin-based architecture exposes an extension API so that it is possible to add support for other frameworks or tailored existing plugins to your specific needs.
 
@@ -60,7 +62,7 @@ $ ./bin/phantomjs decktape.js -h
 
 Usage: phantomjs decktape.js [options] [command] <url> <filename>
 
-command      one of: automatic, csss, deck, dzslides, flowtime, generic, impress,
+command      one of: automatic, bespoke, csss, deck, dzslides, flowtime, generic, impress,
              remark, reveal, shower, slidy
 url          URL of the slides deck
 filename     Filename of the output PDF file

--- a/plugins/bespoke.js
+++ b/plugins/bespoke.js
@@ -1,0 +1,31 @@
+exports.create = function(page) {
+  return {
+    getName: function() { return "Bespoke.js"; },
+    isActive: function() { return page.evaluate(function() { return !!((window.bespoke||{}).deck ? (deck = bespoke.deck) : 0); }); },
+    size: function() { return page.evaluate(function() {
+      var style = getComputedStyle(deck.slides[0]);
+      return { width: parseInt(style.width, 10), height: parseInt(style.height, 10) };
+    }); },
+    slideCount: function() { return page.evaluate(function() { return deck.slides.length; }); },
+    configure: function() { page.evaluate(function() {
+      document.body.classList.add('export');
+      if (deck.parent.classList.contains('bespoke-overview')) deck.fire('overview');
+      deck.slide(0);
+      // advance to last build on first slide (internal state in bespoke-bullets makes this tricky)
+      var builds = 0, one = (deck.slides.length === 1);
+      if (one) deck.slides.push(document.createElement('section'));
+      do ++builds && deck.next(); while (deck.slide() === 0);
+      for (var i = 0; i < builds; i++) i === 0 ? deck.slide(0) : deck.next();
+      if (one) deck.slides.splice(-1, 1);
+    }); },
+    currentSlideIndex: function() { return page.evaluate(function() { return deck.slide() + 1; }); },
+    nextSlide: function() { page.evaluate(function() {
+      // advance to last build on next slide (internal state in bespoke-bullets makes this tricky)
+      var next = deck.slide() + 1, beforeLast = (next === deck.slides.length - 1), builds = 0;
+      if (beforeLast) deck.slides.push(document.createElement('section'));
+      do ++builds && deck.next(); while (deck.slide() <= next);
+      for (var i = 1; i < builds; i++) i === 1 ? deck.slide(next) : deck.next();
+      if (beforeLast) deck.slides.splice(-1, 1);
+    }); }
+  };
+};


### PR DESCRIPTION
If Bespoke.js is configured in one of the following ways, this converter will be activated.

```js
var bespoke = require('bespoke');

(window.bespoke = bespoke).deck = bespoke.from('.deck', [
  // plugins
]);
```

or

```js
var bespoke = require('bespoke'),
  extern = require('bespoke-extern');

bespoke.from('.deck', [
  // additional plugins
  extern(bespoke)
]);
```

More details can be found here: https://github.com/opendevise/bespoke-extern#usage

This plugin auto-advances to the last build item on each slide. Once decktape supports the option to control whether slides are created per fragment, the plugin should be updated accordingly.