### PR TITLE
Added ability to sleep between page load and starting to print slides.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -6,6 +6,7 @@ Antonin Stefanutti <https://github.com/astefanutti[@astefanutti]>
 :idprefix:
 :idseparator: -
 // Aliases
+:bullet: &#8201;&#8226;&#8201;
 ifdef::env-github[]
 :icon-ban: :no_entry_sign:
 :icon-check: :white_check_mark:
@@ -56,23 +57,12 @@ DeckTape is built on top of {uri-phantomjs}[PhantomJS] which relies on {uri-qt-w
 
 DeckTape currently supports the following presentation frameworks out of the box:
 
-[cols="4*.<a",width="100%",grid="none"]
-|===
-|
-* {uri-bespokejs}[Bespoke.js]
-* {uri-csss}[CSSS]
-* {uri-deckjs}[deck.js]
-|
-* {uri-dzslides}[DZSlides]
-* {uri-flowtimejs}[Flowtime.js]
-* {uri-impressjs}[impress.js]
-|
-* {uri-remark}[remark]
-* {uri-revealjs}[reveal.js]
-* {uri-shower}[Shower]
-|
-* {uri-slidy}[Slidy]
-|===
+[subs="normal"]
+....
+{bullet}{uri-bespokejs}[Bespoke.js]     {bullet}{uri-dzslides}[DZSlides]        {bullet}{uri-remark}[remark]        {bullet}{uri-slidy}[Slidy]
+{bullet}{uri-csss}[CSSS]           {bullet}{uri-flowtimejs}[Flowtime.js]     {bullet}{uri-revealjs}[reveal.js]
+{bullet}{uri-deckjs}[deck.js]        {bullet}{uri-impressjs}[impress.js]      {bullet}{uri-shower}[Shower]
+....
 
 DeckTape also provides a <<generic,generic command>> that works by emulating the end-user interaction, allowing it to be used to convert presentations from virtually any kind of framework.
 The generic mode is particularly useful for supporting HTML presentation frameworks that don't expose an API or accessible state.

--- a/README.adoc
+++ b/README.adoc
@@ -34,7 +34,6 @@ endif::[]
 :uri-docker-ref: http://docs.docker.com/engine/reference
 :uri-dzslides: http://paulrouget.com/dzslides
 :uri-flowtimejs: http://flowtime-js.marcolago.com
-:uri-html-slidy: http://www.w3.org/Talks/Tools/Slidy/
 :uri-impressjs: http://impress.github.io/impress.js
 :uri-pageres: https://github.com/sindresorhus/pageres
 :uri-phantomjs: http://phantomjs.org
@@ -45,6 +44,7 @@ endif::[]
 :uri-remark: http://remarkjs.com
 :uri-revealjs: http://lab.hakim.se/reveal-js
 :uri-shower: http://shwr.me
+:uri-slidy: http://www.w3.org/Talks/Tools/Slidy/
 :uri-qt-webkit: https://wiki.qt.io/Qt_WebKit
 :uri-qt-webkit-build: https://wiki.qt.io/Building_Qt_5_from_Git
 
@@ -65,13 +65,13 @@ DeckTape currently supports the following presentation frameworks out of the box
 |
 * {uri-dzslides}[DZSlides]
 * {uri-flowtimejs}[Flowtime.js]
-* {uri-html-slidy}[HTML Slidy]
-|
 * {uri-impressjs}[impress.js]
+|
 * {uri-remark}[remark]
 * {uri-revealjs}[reveal.js]
-|
 * {uri-shower}[Shower]
+|
+* {uri-slidy}[Slidy]
 |===
 
 DeckTape also provides a <<generic,generic command>> that works by emulating the end-user interaction, allowing it to be used to convert presentations from virtually any kind of framework.
@@ -224,7 +224,7 @@ The following slide deck examples have been exported using DeckTape:
 |https://astefanutti.github.io/decktape/examples/remark-js-slideshow.pdf[remark-js-slideshow.pdf] (0.7MB)
 
 |http://www.w3.org/Talks/Tools/Slidy[HTML Slidy: Slide Shows in HTML and XHTML]
-|HTML Slidy
+|Slidy
 |https://astefanutti.github.io/decktape/examples/html-slidy-presentation.pdf[html-slidy-presentation.pdf] (0.5MB)
 
 |http://leaverou.github.io/csss[CSSS: CSS-based SlideShow System]


### PR DESCRIPTION
Decktape assumes everything is ready after the onload. For my purposes, the loads are asynchronous. I've added a configurable sleep between the page loading and starting to print the slides. This can be configured with `loadpause`.