### PR TITLE
add a package.json file in order to simplify the way decktape is laun…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "decktape",
+  "version": "1.0.0",
+  "description": "high-quality PDF exporter for HTML5 presentation frameworks",
+  "main": "decktape.js",
+  "scripts": {
+    "start": "./bin/phantomjs decktape.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/astefanutti/decktape.git"
+  },
+  "author": "astefanutti",
+  "license": "unknown",
+  "bugs": {
+    "url": "https://github.com/astefanutti/decktape/issues"
+  },
+  "homepage": "https://github.com/astefanutti/decktape"
+}


### PR DESCRIPTION
…ched

With this package.json file, it is simpler to launch decktape. You no longer need to type the strange `./bin/phantomjs decktape.js` as it is embedded in the package.json file.

You now have to enter one of the following command:

```bash
npm start <command> <url> <file>
npm start remark http://presentation.example.com> my-exported-presentation.pdf
```

This makes the user interface more consistent and easy to use.

Other script aliases can also be easily defined.