### PR TITLE
feat(): add a default mounted volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,5 +26,7 @@ RUN curl -k \
 
 RUN chmod +x bin/phantomjs
 
-ENTRYPOINT ["/decktape/bin/phantomjs", "decktape.js"]
+WORKDIR /slides
+
+ENTRYPOINT ["/decktape/bin/phantomjs", "/decktape/decktape.js"]
 CMD ["-h"]

--- a/README.adoc
+++ b/README.adoc
@@ -263,15 +263,15 @@ For example:
 
 * To convert an online HTML presentation and have it exported into the working directory under the `slides.pdf` filename:
 [source,shell,subs=attributes+]
- $ docker run --rm -v `pwd`:/pwd astefanutti/decktape {uri-revealjs} /pwd/slides.pdf
+ $ docker run --rm -v `pwd`:/slides astefanutti/decktape {uri-revealjs} slides.pdf
 
 * Or, to convert an HTML presentation that's stored on the local file system in the `home` directory:
 [source,shell]
- $ docker run --rm -v `pwd`:/pwd -v ~:/home astefanutti/decktape /home/slides.html /pwd/slides.pdf
+ $ docker run --rm -v `pwd`:/slides -v ~:/home/user astefanutti/decktape /home/user/slides.html slides.pdf
 
 * Or, to convert an HTML presentation that's deployed on the local host:
 [source,shell]
- $ docker run --rm --net=host -v `pwd`:/pwd astefanutti/decktape http://localhost:8000 /pwd/slides.pdf
+ $ docker run --rm --net=host -v `pwd`:/slides astefanutti/decktape http://localhost:8000 slides.pdf
 
 It is recommended to use the following options from the {uri-docker-ref}/run[`docker run`] command:
 


### PR DESCRIPTION
Add a default mounted volume so that the pdf file does not need to be prefixed anymore.