### PR TITLE
Use "networkidle2" lifecycle event to make page loading work with data uri resources

### DIFF
--- a/decktape.js
+++ b/decktape.js
@@ -202,7 +202,7 @@ process.on('unhandledRejection', error => {
 
   console.log('Loading page', options.url, '...');
   const load = page.waitForNavigation({ waitUntil: 'load', timeout: 20000 });
-  page.goto(options.url, { waitUntil: 'networkidle0', timeout: 60000 })
+  page.goto(options.url, { waitUntil: 'networkidle2', timeout: 60000 })
     // wait until the load event is dispatched
     .then(response => load
       .catch(error => response.status() !== 200 ? Promise.reject(error) : response)


### PR DESCRIPTION
Dear Antonin,

after starting to [use image elements with data uri resources](https://github.com/posterkit/posterkit-sandbox/commit/fd27782c#diff-170a6d42d4c00a9d6e651244bdb33378R410) in [PosterKit](https://github.com/posterkit/posterkit-sandbox) to work around the [CSS image masking problems with SVG images](https://github.com/posterkit/posterkit-sandbox/issues/2#issuecomment-388431859) (also tracked here as https://github.com/astefanutti/decktape/issues/149), we found DeckTape to stall indefinitely until timing out, obviously not receiving an appropriate page load event.

After reading about [earlier freezing issues of the same origin](https://github.com/GoogleChrome/puppeteer/issues/728#issuecomment-351432657), we found using the `networkidle2` lifecycle event [works great for us](https://github.com/GoogleChrome/puppeteer/issues/1552#issuecomment-388559555), as it also [does for others](https://github.com/GoogleChrome/puppeteer/issues/1552#issuecomment-357103028):

@tomgallagher commented on Jan 11
> I think the networkidle2 is genius. I've been looking for this event in Javascript or the Chrome Extension APIs for years.

@aslushnikov commented on Jan 12 
> Thank you, we're happy it helps!

----

This PR does just that: Use the `networkidle2` lifecycle event instead of `networkidle0`.

Thanks in advance for your efforts, hope this helps.
