### PR TITLE
#165: Add FAQ about `no usable sandbox` errors to docs.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -294,6 +294,10 @@ $ npm i -g --production windows-build-tools
 +
 Yes, it is available at https://aur.archlinux.org/packages/nodejs-decktape/.
 
+* *_I'm getting an error: No usable sandbox!_*
++
+Arch Linux, among other Linux distributions may have the user namespace in the kernel disabled by default. You can verify this by accessing _chrome://sandbox_ in your chrom[e|ium] browser. You can find more about sandboxing, https://chromium.googlesource.com/chromium/src/+/master/docs/linux_sandboxing.md#User-namespaces-sandbox[here]. As a _temporary_ work-around, you can pass `--no-sandbox` as a CLI option.
+
 == Plugin API
 
 {icon-edit}


### PR DESCRIPTION
As discussed in issue #165, I'm adding relevant FAQ information about sandbox errors for other Linux users that might run into this issue.