### PR TITLE
make rendering of substeps as separate page optional

### DIFF
--- a/decktape.js
+++ b/decktape.js
@@ -51,6 +51,13 @@ parser.script('decktape').options({
     default : 0,
     help    : 'Duration in milliseconds between the page has loaded and starting to export slides',
   },
+  enableSubsteps: {
+    abbr: 'substeps',
+    metavar: '<true|false>',
+    type: 'boolean',
+    help: 'If substeps should be used as separate slides',
+    default: true
+  },
   screenshots : {
     default : false,
     flag    : true,
@@ -299,8 +306,18 @@ async function exportSlides(plugin, page, printer) {
     exportedSlides      : 0,
     pdfFonts            : {},
     pdfXObjects         : {},
-    totalSlides         : await plugin.slideCount(),
+    totalSlides         : await plugin.slideCount(options.enableSubsteps),
   };
+
+  if(options.enableSubsteps===false){
+    page.$$eval('.substep', substeps => {
+      substeps.forEach(substep=>{
+        substep.classList.remove('substep');
+        substep.classList.add('substep-visible');
+      });
+    })
+  }
+
   // TODO: support a more advanced "fragment to pause" mapping
   // for special use cases like GIF animations
   // TODO: support plugin optional promise to wait until a particular mutation

--- a/decktape.js
+++ b/decktape.js
@@ -365,6 +365,7 @@ async function exportSlide(plugin, page, printer, context) {
     printBackground     : true,
     pageRanges          : '1',
     displayHeaderFooter : false,
+    scale: 1.5
   });
   printSlide(printer, new BufferReader(buffer), context);
   context.exportedSlides++;

--- a/plugins/impress.js
+++ b/plugins/impress.js
@@ -22,9 +22,15 @@ class Impress {
     });
   }
 
-  slideCount() {
+  slideCount(enableSubsteps) {
+    if(enableSubsteps){
+      return this.page.evaluate(_ =>
+          document.querySelectorAll('#impress .step, #impress .substep').length);
+    }
     return this.page.evaluate(_ =>
-      document.querySelectorAll('#impress .step, #impress .substep').length);
+        document.querySelectorAll('#impress .step').length);
+
+
   }
 
   nextSlide() {


### PR DESCRIPTION
Sometimes you want to have all the substeps immediately visible in pdf files and not as separate pages for every substep. With these changes, there will be a `--substeps=false` option to disable generation of pages for each substep.