### PR TITLE
Add support for NueDeck

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -112,7 +112,7 @@ Usage: decktape [options] [command] <url> <filename>
        decktape version
 
 command      one of: automatic, bespoke, csss, deck, dzslides, flowtime, generic, impress,
-             remark, reveal, shower, slidy, webslides
+             nuedeck, remark, reveal, shower, slidy, webslides
 url          URL of the slides deck
 filename     Filename of the output PDF file
 

--- a/README.adoc
+++ b/README.adoc
@@ -47,6 +47,7 @@ endif::[]
 :uri-dzslides: http://paulrouget.com/dzslides
 :uri-flowtimejs: http://flowtime-js.marcolago.com
 :uri-impressjs: http://impress.github.io/impress.js
+:uri-nuedeck: https://github.com/twitwi/nuedeck
 :uri-pageres: https://github.com/sindresorhus/pageres
 :uri-remark: http://remarkjs.com
 :uri-revealjs: http://lab.hakim.se/reveal-js
@@ -65,9 +66,10 @@ DeckTape currently supports the following presentation frameworks out of the box
 
 [subs="normal"]
 ....
-{bullet}{uri-bespokejs}[Bespoke.js]      {bullet}{uri-dzslides}[DZSlides]        {bullet}{uri-remark}[remark]          {bullet}{uri-shower}[Shower]
-{bullet}{uri-csss}[CSSS]            {bullet}{uri-flowtimejs}[Flowtime.js]     {bullet}{uri-revealjs}[reveal.js]       {bullet}{uri-slidy}[Slidy]
-{bullet}{uri-deckjs}[deck.js]         {bullet}{uri-impressjs}[impress.js]      {bullet}{uri-rise}[RISE]            {bullet}{uri-webslides}[WebSlides]
+{bullet}{uri-bespokejs}[Bespoke.js]      {bullet}{uri-flowtimejs}[Flowtime.js]     {bullet}{uri-revealjs}[reveal.js]       {bullet}{uri-webslides}[WebSlides]
+{bullet}{uri-csss}[CSSS]            {bullet}{uri-impressjs}[impress.js]      {bullet}{uri-rise}[RISE]             .
+{bullet}{uri-deckjs}[deck.js]         {bullet}{uri-nuedeck}[NueDeck]         {bullet}{uri-shower}[Shower]           .
+{bullet}{uri-dzslides}[DZSlides]        {bullet}{uri-remark}[remark]          {bullet}{uri-slidy}[Slidy]            .
 ....
 
 DeckTape also provides a <<generic,generic command>> that works by emulating the end-user interaction, allowing it to be used to convert presentations from virtually any kind of framework.

--- a/plugins/nuedeck.js
+++ b/plugins/nuedeck.js
@@ -1,0 +1,33 @@
+exports.create = page => new NueDeck(page);
+
+class NueDeck {
+
+  constructor(page) {
+    this.page = page;
+  }
+
+  getName() {
+    return 'NueDeck';
+  }
+
+  size() {
+    return this.page.evaluate(_ => ({ width: nuedeck.opts.core.designWidth,
+                                      height: nuedeck.opts.core.designHeight }));
+  }
+
+  isActive() {
+    return this.page.evaluate(_ => typeof nuedeck !== 'undefined');
+  }
+
+  slideCount() {
+    return this.page.evaluate(_ => nuedeck.slideCount);
+  }
+
+  nextSlide() {
+    return this.page.evaluate(_ => nuedeck.jumpToSlide(nuedeck.currentSlide + 1, -1));
+  }
+
+  currentSlideIndex() {
+    return this.page.evaluate(_ => nuedeck.currentSlide);
+  }
+}


### PR DESCRIPTION
This plugin is for NueDeck (a reboot of deck.js (and many extensions), using Vue.js, https://github.com/twitwi/nuedeck )

I don't know what is the policy for including new plugins into the main repo:
- NueDeck is currently very new, is this blocking?
- should I update the decktape readme for the PR?
- also, is there a way for a plugin to change the default "pause"?

Thanks for working on decktape.