### PR TITLE
Corrected Spectacle's Link

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -246,7 +246,7 @@ The following slide deck examples have been exported using DeckTape:
 |Bespoke.js
 |https://astefanutti.github.io/decktape/examples/new-es5-overloards.pdf[new-es5-overloards.pdf] (0.2MB)
 
-|https://stack.formidable.com/spectacle[Spectacle: A ReactJS Presentation Library]
+|https://formidable.com/open-source/spectacle/[Spectacle: A ReactJS Presentation Library]
 |Spectacle
 |https://astefanutti.github.io/decktape/examples/spectacle-reactjs-presentation.pdf[spectacle-reactjs-presentation.pdf] (8.9MB)
 |===


### PR DESCRIPTION
The link poiniting to spectacle's website gave a 404. So updated with the current link