### PR TITLE
Feature/override timeouts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ FROM alpine:3.15.0
 
 LABEL org.opencontainers.image.source="https://github.com/astefanutti/decktape"
 
-ARG CHROMIUM_VERSION=103.0.5060.53-r0
+ARG CHROMIUM_VERSION=104.0.5112.101-r0
 ENV TERM xterm-color
 
 RUN <<EOF cat > /etc/apk/repositories

--- a/README.adoc
+++ b/README.adoc
@@ -126,6 +126,10 @@ Options:
    -p <ms>, --pause <ms>           Duration in milliseconds before each slide is exported  [1000]
    --load-pause <ms>               Duration in milliseconds between the page has loaded
                                    and starting to export slides  [0]
+   --url-load-timeout <ms>         Timeout in milliseconds to use when waiting for the initial 
+                                   URL to load  [60000]
+   --page-load-timeout <ms>        Timeout in milliseconds to use when waiting for the slide deck 
+                                   page to load  [20000]
    --screenshots                   Capture each slide as an image  [false]
    --screenshots-directory <dir>   Screenshots output directory  [screenshots]
    --screenshots-size <size>       Screenshots resolution, can be repeated  [--size]

--- a/decktape.js
+++ b/decktape.js
@@ -51,6 +51,18 @@ parser.script('decktape').options({
     default : 0,
     help    : 'Duration in milliseconds between the page has loaded and starting to export slides',
   },
+  urlLoadTimeout: {
+    full: 'url-load-timeout',
+    metavar: '<ms>',
+    default: 60000,
+    help: 'Timeout in milliseconds to use when waiting for the initial URL to load',
+  },
+  pageLoadTimeout: {
+    full: 'page-load-timeout',
+    metavar: '<ms>',
+    default: 20000,
+    help: 'Timeout in milliseconds to use when waiting for the slide deck page to load',
+  },
   screenshots : {
     default : false,
     flag    : true,
@@ -242,8 +254,8 @@ process.on('unhandledRejection', error => {
     .on('pageerror', error => console.log(chalk`\n{red Page error: ${error.message}}`));
 
   console.log('Loading page', options.url, '...');
-  const load = page.waitForNavigation({ waitUntil: 'load', timeout: 20000 });
-  page.goto(options.url, { waitUntil: 'networkidle0', timeout: 60000 })
+  const load = page.waitForNavigation({ waitUntil: 'load', timeout: options.urlLoadTimeout });
+  page.goto(options.url, { waitUntil: 'networkidle0', timeout: options.pageLoadTimeout })
     // wait until the load event is dispatched
     .then(response => load
       .catch(error => response.status() !== 200 ? Promise.reject(error) : response)


### PR DESCRIPTION
Move the two url/page load timeouts into options that the user can control.  I found this necessary when loading local slides with a lot of pages that contain high-res images.  The options defaults are what the code originally had so if the user does not use them there is no change to their experience.  README also updated.

Additionally, my use case uses Docker so I needed to update the docker file with a newer chromium version in order to build.