### PR TITLE
Add timeout to pdf buffering for slide

### DIFF
--- a/decktape.js
+++ b/decktape.js
@@ -63,6 +63,12 @@ parser.script('decktape').options({
     default: 20000,
     help: 'Timeout in milliseconds to use when waiting for the slide deck page to load',
   },
+  bufferTimeout: {
+    full: 'buffer-timeout',
+    metavar: '<ms>',
+    default: 30000,
+    help: 'Timeout in milliseconds to use when waiting for a slide to finish buffering (set to 0 to disable)',
+  },
   screenshots : {
     default : false,
     flag    : true,
@@ -387,6 +393,7 @@ async function exportSlide(plugin, page, pdf, context) {
     printBackground     : true,
     pageRanges          : '1',
     displayHeaderFooter : false,
+    timeout             : options.bufferTimeout,
   });
   await printSlide(pdf, await PDFDocument.load(buffer, { parseSpeed: ParseSpeeds.Fastest }), context);
   context.exportedSlides++;


### PR DESCRIPTION
I added a timeout to `pdf.page` so that you can customize how long you will wait for slides with large assets to finish buffering. 

I had a complicated plotly graph that was causing the buffer to take much longer than the default of 30 seconds. This was the only way I was able to mitigate the issue.