### PR TITLE
feat(revealjs): disable menu open button

### DIFF
--- a/plugins/reveal.js
+++ b/plugins/reveal.js
@@ -38,6 +38,8 @@ class Reveal {
           transition: 'none'
         });
 
+        // This is a workaround to disable the open button of the RevealMenu plugin.
+        // See the following issue for more details: https://github.com/denehyg/reveal.js-menu/issues/99
         var menuOpenButtons = document.getElementsByClassName('slide-menu-button');
         for (var i = 0; i < menuOpenButtons.length; i++) {
           menuOpenButtons[i].style.display = 'none';

--- a/plugins/reveal.js
+++ b/plugins/reveal.js
@@ -30,12 +30,19 @@ class Reveal {
   }
 
   configure() {
-    return this.page.evaluate(fragments => Reveal.configure({
-        controls  : false,
-        progress  : false,
-        fragments : fragments,
-        transition: 'none'
-      }),
+    return this.page.evaluate(fragments => {
+        Reveal.configure({
+          controls  : false,
+          progress  : false,
+          fragments : fragments,
+          transition: 'none'
+        });
+
+        var menuOpenButtons = document.getElementsByClassName('slide-menu-button');
+        for (var i = 0; i < menuOpenButtons.length; i++) {
+          menuOpenButtons[i].style.display = 'none';
+        }
+      },
       // It seems passing 'fragments=true' in the URL query string does not take precedence
       // over globally configured 'fragments' and prevents from being able to toggle fragments
       // with ...?fragments=<true|false> so we work around that by parsing the page query string


### PR DESCRIPTION
This is a workaround for denehyg/reveal.js-menu#99

When the RevealMenu plugin is enabled, there is a menu button on the printed slides.

This change disables that menu during printing.

This isn't necessarily the best possible solution, but since there is no "official" API for updating plugin configuration and the RevealMenu plugin does not expose any destroy or hide button API, this is the best alternative at the moment.