### PR TITLE
ci: Revert pull_request event types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,6 @@ name: CI
 
 on:
   pull_request:
-    types: 
-      - opened
-      - synchronize
-      - reopened
     branches:
       - master
     paths-ignore:


### PR DESCRIPTION
It's not the types that prevents the CI workflow from being triggered from the update snapshots one. It's the usage of `secrets.GITHUB_TOKEN` as documented in https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow.