### PR TITLE
ci: Trigger CI workflow after the snapshots update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ on:
       - '**.adoc'
       - '**.md'
       - 'LICENSE'
+  repository_dispatch:
   schedule:
     - cron: '0 12 * * *'
 

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -1,4 +1,4 @@
-name: Update snapshots
+name: Update Snapshots
 on:
   workflow_dispatch:
 
@@ -21,3 +21,14 @@ jobs:
           git add .
           git commit -m "test: update snapshot PDFs"
           git push
+      - name: Trigger CI Workflow
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'ci.yml',
+              ref: context.ref,
+            })


### PR DESCRIPTION
https://github.blog/changelog/2022-09-08-github-actions-use-github_token-with-workflow_dispatch-and-repository_dispatch/