### PR TITLE
ci: Use workflow_dispatch instead of repository_dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ on:
       - '**.adoc'
       - '**.md'
       - 'LICENSE'
-  repository_dispatch:
+  workflow_dispatch:
   schedule:
     - cron: '0 12 * * *'
 


### PR DESCRIPTION
Follows up #268.