### PR TITLE
Add hackmd.io plugin

### DIFF
--- a/plugins/hackmd.js
+++ b/plugins/hackmd.js
@@ -1,0 +1,55 @@
+import { pause } from '../libs/util.js';
+
+export const create = page => new Hackmd(page);
+
+class Hackmd {
+
+  constructor(page) {
+    this.page = page;
+    this.currentSlide = 1;
+    this.isNextSlideDetected = false;
+    this.media = 'screen';
+  }
+
+  getName() {
+    return 'Hackmd slide mode';
+  }
+
+  isActive() {
+    return this.page.evaluate(_ => window.domain  === 'hackmd.io');
+  }
+
+  async configure() {
+    await this.page.emulateMediaType(this.media);
+    await this.page.exposeFunction('onMutation', _ => (this.isNextSlideDetected = true));
+    await this.page.evaluate(_ =>
+      new MutationObserver(_ => window.onMutation()).observe(document, {
+        attributes : true,
+        childList  : true,
+        subtree    : true,
+      })
+    );
+  }
+
+  slideCount() {
+    return undefined;
+  }
+
+  async hasNextSlide() {    
+    let cantgodown = await this.page.$eval('.navigate-down', ({ disabled }) => disabled);
+    await this.page.keyboard.press(cantgodown ? 'ArrowRight' : 'ArrowDown');
+    await pause(1000);
+    return this.isNextSlideDetected;
+  }
+
+  nextSlide() {
+    this.currentSlide++;
+    this.isNextSlideDetected = false;
+  }
+
+  async currentSlideIndex() {
+    const hash = await this.page.evaluate(_ => window.location.hash);
+    const [, fragment] = hash.match(/^#\/?([^?]*)/) || [];
+    return fragment || this.currentSlide;
+  }
+}


### PR DESCRIPTION
I like [HackMD](https://hackmd.io) a lot which now has a [slide mode](https://hackmd.io/s/how-to-create-slide-deck). Although it uses reveal.js under the hood, I couldn't see how to get at the `Reveal` object itself. But you can advance using the down arrow, or right arrow if not possible to go down. Since this could not be done with `generic`, I made a new plugin.

It worked when I ran it on my computer. And if you do or don't want slide fragments, you can just change that in the HackMD url like `?fragments=false`.

related to https://github.com/hackmdio/codimd/issues/33 and https://github.com/hackmdio/hackmd-io-issues/issues/161 . Note that the `?print-pdf` option from HackMD wasn't working for my slide deck, it would make an extra empty slide in some places and not respect the additional CSS styling on the images.