### PR TITLE
Add secondaryKey option for 2d navigation

### DIFF
--- a/plugins/generic.js
+++ b/plugins/generic.js
@@ -10,6 +10,10 @@ export const options = {
     metavar : '<key>',
     help    : 'Key pressed to navigate to next slide',
   },
+  secondaryKey : {
+    metavar : '<secondaryKey>',
+    help    : 'Key pressed to navigate to next slide IF usual key has no effect',
+  },
   maxSlides : {
     full    : 'max-slides',
     metavar : '<size>',
@@ -29,7 +33,8 @@ and iterates over the presentation as long as:
 - Any change to the DOM is detected by observing mutation events targeting the body element
   and its subtree,
 - Nor the number of slides exported has reached the specified --max-slides option.
-  The --key option must be one of the 'KeyboardEvent' keys and defaults to [${options.key.default}].`;
+  The --key option must be one of the 'KeyboardEvent' keys and defaults to [${options.key.default}].
+  For 2D navigation, use the --secondaryKey option.`;
 
 export const create = (page, opts) => new Generic(page, opts);
 
@@ -41,6 +46,7 @@ class Generic {
     this.isNextSlideDetected = false;
     this.key = this.options.key || options.key.default;
     this.media = this.options.media || options.media.default;
+    this.secondaryKey = this.options.secondaryKey;
   }
 
   getName() {
@@ -79,6 +85,11 @@ class Generic {
     // TODO: detect cycle to avoid infinite navigation for frameworks
     // that support loopable presentations like impress.js and flowtime.js
     await pause(1000);
+
+    if (!this.isNextSlideDetected && (typeof this.secondaryKey !== 'undefined')) {
+      await this.page.keyboard.press(this.secondaryKey);
+      await pause(1000);
+    }
     return this.isNextSlideDetected;
   }
 


### PR DESCRIPTION
fixes #290 

For example, my use case is

```
node decktape.js  --key=ArrowDown automatic 'https://hackmd.io/@kmarw/SJxRLR3DO2?controls=false&fragments=false' ~/test.pdf
```

There is a bug however; the first slide seems to print twice. Why is this? 
This happens:
* on this branch, when I use a secondary key or not.
* on the latest release, when the `key` does not advance the slides.

It does not happen
* on the latest release, when the `key` advances the slides.
* on my previous branch https://github.com/astefanutti/decktape/pull/289

My guess is that it happens when the first `key` is pressed, and nothing has changed, but perhaps the page is still loading, so `isNextSlideDetected` is set to `true`. Just a hypothesis though. (For example, on my slide deck, the first slide advances with the `secondaryKey`, i.e. the `key` doesn't advance the slide.)