### PR TITLE
Fix: asynchronously wait for the browser to close before exiting the process

### DIFF
--- a/decktape.js
+++ b/decktape.js
@@ -303,12 +303,14 @@ process.on('unhandledRejection', error => {
       .then(async context => {
         await writePdf(options.filename, pdf);
         console.log(chalk.green(`\nPrinted ${chalk.bold('%s')} slides`), context.exportedSlides);
-        browser.close();
+        // Wait for the browser to close before exiting the process
+        await browser.close();
         process.exit();
       }))
-    .catch(error => {
+    .catch(async error => {
       console.log(chalk.red('\n%s'), error);
-      browser.close();
+      // Wait for the browser to close before exiting the process
+      await browser.close();
       process.exit(1);
     });
 })();


### PR DESCRIPTION
Decktape doesn't wait for the browser to close before exiting the node process. This causes the browser to crash and not to remove temporary files, leaving them in `/tmp` directory.

See: https://pptr.dev/api/puppeteer.browser.close

Related issue: https://github.com/astefanutti/decktape/issues/295