### PR TITLE
Add changes for better rendering of mermaid diagrams

### DIFF
--- a/plugins/reveal.js
+++ b/plugins/reveal.js
@@ -82,7 +82,8 @@ class Reveal {
   }
 
   nextSlide() {
-    return this.page.evaluate(_ => Reveal.next());
+    this.page.evaluate(_ => Reveal.next());
+    return this.page.evaluate(_ => Reveal.layout());
   }
 
   currentSlideIndex() {


### PR DESCRIPTION
This slight addition makes that mermaid diagrams are correctly rendered. They otherwise somehow end up below the page.