### PR TITLE
Fix merging embedded fonts

### DIFF
--- a/decktape.js
+++ b/decktape.js
@@ -509,9 +509,7 @@ async function printSlide(pdf, slide, context) {
         if (!font.data['OS/2']) {
           font.data['OS/2'] = {};
         }
-        // PDF font name does not contain sub family on Windows 10,
-        // so a more robust key is computed from the font metadata
-        const id = descriptor.get(PDFName.of('FontName')).value() + ' - ' + fontMetadataKey(font.data.name);
+        const id = crypto.createHash('SHA1').update(Buffer.from(bytes)).digest('hex');
         if (context.pdfFonts[id]) {
           const f = context.pdfFonts[id].font;
           font.data.glyf.forEach((g, i) => {


### PR DESCRIPTION
I have been using [d2](https://d2lang.com/) to create diagrams in my revealjs presentations, which are embedded as svg files. The svg files have embedded fonts with the same name, but different glyphs. This has been causing issues when attempting to merge the fonts.

```
Error: Repeat unicode, glyph index: 9
    at Object.raise (/nix/store/0l2sgyrb6ggd4nv5balc2svq8g83dry4-decktape/lib/node_modules/decktape/node_modules/fonteditor-core/lib/ttf/error.js:45:17)
    at /nix/store/0l2sgyrb6ggd4nv5balc2svq8g83dry4-decktape/lib/node_modules/decktape/node_modules/fonteditor-core/lib/ttf/ttfwriter.js:78:33
    at Array.forEach (<anonymous>)
    at /nix/store/0l2sgyrb6ggd4nv5balc2svq8g83dry4-decktape/lib/node_modules/decktape/node_modules/fonteditor-core/lib/ttf/ttfwriter.js:76:24
    at Array.forEach (<anonymous>)
    at TTFWriter.resolveTTF (/nix/store/0l2sgyrb6ggd4nv5balc2svq8g83dry4-decktape/lib/node_modules/decktape/node_modules/fonteditor-core/lib/ttf/ttfwriter.js:73:16)
    at TTFWriter.write (/nix/store/0l2sgyrb6ggd4nv5balc2svq8g83dry4-decktape/lib/node_modules/decktape/node_modules/fonteditor-core/lib/ttf/ttfwriter.js:221:12)
    at Font.write (/nix/store/0l2sgyrb6ggd4nv5balc2svq8g83dry4-decktape/lib/node_modules/decktape/node_modules/fonteditor-core/lib/ttf/font.js:156:53)
    at file:///nix/store/0l2sgyrb6ggd4nv5balc2svq8g83dry4-decktape/lib/node_modules/decktape/decktape.js:402:58
    at Array.forEach (<anonymous>) {
  number: 10200,
  data: 9
}
```

This change will hash each font and only attempt to merge them if the fonts are identical (hashes match). This fully resolves the problem for me.