### PR TITLE
Workaround reveal.js's Chalkboard extension buttons appearing in printouts

### DIFF
--- a/plugins/reveal.js
+++ b/plugins/reveal.js
@@ -54,11 +54,14 @@ class Reveal {
           autoAnimate: false,
         });
 
-        // This is a workaround to disable the open button of the RevealMenu plugin.
+        // This is a workaround to disable the open button of the RevealMenu plugin
+        // and to disable the open button of the Chalkboard plugin.
         // See the following issue for more details: https://github.com/denehyg/reveal.js-menu/issues/99
-        var menuOpenButtons = document.getElementsByClassName('slide-menu-button');
-        for (var i = 0; i < menuOpenButtons.length; i++) {
-          menuOpenButtons[i].style.display = 'none';
+        for (const menuClass of ['slide-menu-button', 'slide-chalkboard-buttons']) {
+          var menuOpenButtons = document.getElementsByClassName(menuClass);
+          for (var i = 0; i < menuOpenButtons.length; i++) {
+            menuOpenButtons[i].style.display = 'none';
+          }
         }
       },
       {


### PR DESCRIPTION
Addresses issue #379, at least for the way quarto configures reveal.js's chalkboard plugin by default.

This just extends the workaround used to hide reveal.js menus.