### PR TITLE
npm bin no longer exists

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -100,7 +100,7 @@ Or locally:
 
 ```sh
 $ npm install decktape
-$ `npm bin`/decktape
+$ npm exec decktape
 ```
 
 See the <<faq,FAQ>> for troubleshooting / alternatives.


### PR DESCRIPTION
I spent ages trying to figure this out, and it turns out [npm bin has been removed](https://github.blog/changelog/2022-10-24-npm-v9-0-0-released/) from npm. Replace with `exec` is, I hope, the correct way.